### PR TITLE
feat: add GitHub Actions workflow for PHPCS inspections on pull requests

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: none
           tools: cs2pr, composer:v2
 

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -40,11 +40,12 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress || composer update --prefer-dist --no-progress
 
-      - id: changes
+      - name: Detect coding standard violations
         run: |
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          FILES=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s -X GET -G $URL | jq -r '.[] | .filename' | xargs)
-          echo "files=$FILES" >> $GITHUB_OUTPUT
-
-      - name: Detect coding standard violations
-        run: vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings
+          readarray -t FILES < <(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s -X GET -G "$URL" | jq -r '.[] | .filename // empty')
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No changed files found."
+            exit 0
+          fi
+          vendor/bin/phpcs "${FILES[@]}" -q --report=checkstyle | cs2pr --graceful-warnings

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,50 @@
+on: pull_request
+
+name: Inspections
+jobs:
+  runPHPCSInspection:
+    name: Run PHPCS inspection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use desired version of NodeJS
+        uses: actions/setup-node@v4
+        with:
+            node-version: 20
+            cache: npm
+
+      - name: Npm install and build
+        run: |
+            npm i
+            npm run build
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+          tools: cs2pr, composer:v2
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}"
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress || composer update --prefer-dist --no-progress
+
+      - id: changes
+        run: |
+          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+          FILES=$(curl --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -s -X GET -G $URL | jq -r '.[] | .filename' | xargs)
+          echo "files=$FILES" >> $GITHUB_OUTPUT
+
+      - name: Detect coding standard violations
+        run: vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -40,7 +40,9 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="texty"/>
+			<property name="text_domain" type="array">
+				<element value="texty"/>
+			</property>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">
@@ -94,7 +96,7 @@
 	<rule ref="WordPress.PHP.StrictInArray.MissingTrueStrict">
 		<type>error</type>
 	</rule>
-	<rule ref="WordPress.PHP.StrictComparisons.LooseComparison">
+	<rule ref="Universal.Operators.StrictComparisons">
 		<type>error</type>
 	</rule>
 	<rule ref="WordPress.DB.DirectDatabaseQuery.DirectQuery">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated PHP coding-standards check on pull requests that runs PHPCS on changed files and surfaces results in PR feedback.
  * Updated the PHP coding-standard configuration to adjust text-domain handling and to switch which strict-comparison rule is enforced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->