### PR TITLE
fix: retry WooCommerce SMS when every recipient send fails

### DIFF
--- a/includes/Notifications/WC/Base.php
+++ b/includes/Notifications/WC/Base.php
@@ -139,8 +139,9 @@ class Base extends Notification {
             return false;
         }
 
-        // mark as sent
-        $this->order->add_meta_data( $meta_key, 1 );
+        // Claim the send up-front so concurrent status changes stay at-most-once.
+        // update_meta_data (not add_meta_data) keeps exactly one row per order/notification.
+        $this->order->update_meta_data( $meta_key, 1 );
         $this->order->save_meta_data();
 
         if ( 'user' === $this->get_type() ) {
@@ -195,7 +196,8 @@ class Base extends Notification {
          */
         do_action( 'texty_before_notification', $this, $recipients, $content );
 
-        $gateway = texty()->gateways();
+        $gateway  = texty()->gateways();
+        $any_sent = false;
 
         // Stash the active notification so the after-send logger can attach
         // notification_id / notification_group to each SmsStat row without
@@ -204,7 +206,11 @@ class Base extends Notification {
 
         try {
             foreach ( $recipients as $number ) {
-                $gateway->send( $number, $content );
+                $result = $gateway->send( $number, $content );
+
+                if ( ! is_wp_error( $result ) && false !== $result ) {
+                    $any_sent = true;
+                }
             }
         } finally {
             texty()->notifications()->clear_active();
@@ -218,6 +224,16 @@ class Base extends Notification {
          * @param string       $content      The message content
          */
         do_action( 'texty_after_notification', $this, $recipients, $content );
+
+        // Every recipient failed — release the claim so the next matching status
+        // change can retry. A partial success keeps the flag so the recipients
+        // who already received the SMS are not messaged again.
+        if ( ! $any_sent ) {
+            $this->order->delete_meta_data( $meta_key );
+            $this->order->save_meta_data();
+
+            return false;
+        }
 
         return true;
     }


### PR DESCRIPTION
Closes getdokan/texty-pro#30

## Problem
`WC\Base::send()` wrote the `_texty_{id}` idempotency flag **before** dispatching and ignored the gateway result. A transient gateway/network error left the order flagged "sent" forever, so the customer/admin SMS was silently lost and never retried. Two secondary defects compounded it: the flag was written with `add_meta_data` (append, not replace), and a failed send produced no signal.

## Fix
- **Capture the gateway result.** Track `$any_sent` across the recipient loop (`! is_wp_error( $result ) && false !== $result`).
- **Roll back on total failure.** If every recipient failed, `delete_meta_data( $meta_key )` and return `false`, so the next matching status change retries.
- **Preserve at-most-once.** A partial success keeps the flag — recipients who already got the SMS are not messaged again.
- **No meta bloat.** Claim with `update_meta_data` so exactly one `_texty_{id}` row exists per order/notification.
- **Hook order preserved.** `texty_after_notification` still fires in its original position (before the rollback), so the `texty_before_notification` / `texty_after_notification` pairing is unchanged.

The `_texty_{id}` meta key is unchanged (stable contract).

## Acceptance criteria
- [x] All recipients fail → `_texty_{id}` left unset → next matching status change retries.
- [x] At least one recipient succeeds → flag stays set (no duplicate to successful recipients).
- [x] Exactly one `_texty_{id}` meta row per order/notification (`update_meta_data`).
- [x] Status flip-flop (processing → on-hold → processing) still fires each distinct notification id once.

## Verification
- `php -l` clean; `composer phpcs` clean (0 errors) on the changed file.
- Manual UI repro: Twilio active with an invalid Auth Token → set order to Processing → send fails → `_texty_order_customer_processing` is **absent** (was permanently `1` before). Restore the token, re-fire Processing → SMS now sends.

## Known limitations (out of scope, per the issue)
- **Partial-failure retry:** a recipient that fails inside an otherwise-successful batch is not retried (the issue intentionally keeps the flag on any success).
- **Residual race:** read-then-claim is still not atomic, so two concurrent `woocommerce_order_status_changed` firings could both claim and both send. Documented in the issue as an optional `wp_cache_add()` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate notification sends when order status changes happen at the same time.
  * Improved retry behavior so notifications can be sent again if all delivery attempts fail.
  * Kept successful sends marked as sent to avoid repeated notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->