### PR TITLE
fix: don't send an empty SMS when a comment is deleted before send

### DIFF
--- a/includes/Dispatcher.php
+++ b/includes/Dispatcher.php
@@ -7,6 +7,7 @@ use Texty\Integrations\WooCommerce;
 use Texty\Models\SmsStat;
 use WeDevs\WPKit\DataLayer\DataLayerFactory;
 use Texty\Gateways\GatewayInterface;
+use WP_Comment;
 
 /**
  * Dispatcher Class
@@ -76,6 +77,14 @@ class Dispatcher {
      * @return void
      */
     public function new_comment( $comment_id ) {
+        // The comment may have been deleted, trashed, or flagged as spam
+        // (e.g. by an anti-spam plugin hooked on `comment_post`) before this
+        // runs. Bail so we don't render and bill an SMS for a comment that no
+        // longer exists.
+        if ( ! get_comment( $comment_id ) instanceof WP_Comment ) {
+            return;
+        }
+
         $class    = texty()->notifications()->get( 'comment' );
         $notifier = new $class();
 

--- a/includes/Notifications/WP/Comment.php
+++ b/includes/Notifications/WP/Comment.php
@@ -3,6 +3,7 @@
 namespace Texty\Notifications\WP;
 
 use Texty\Notifications\Notification;
+use WP_Comment;
 
 class Comment extends Notification {
 
@@ -52,9 +53,23 @@ EOD;
 
         $comment = get_comment( $this->comment_id );
 
+        // The comment can vanish between the `comment_post` hook and the send
+        // (deleted, trashed, or spam). Bail to the global-key pass instead of
+        // dereferencing null and rendering an empty-bodied message.
+        if ( ! $comment instanceof WP_Comment ) {
+            return $this->replace_global_keys( $message );
+        }
+
         foreach ( $this->replacement_keys() as $search => $value ) {
-            $value   = ( $search === 'post_url' ) ? get_permalink( $comment->comment_post_ID ) : $comment->$value;
-            $message = str_replace( '{' . $search . '}', $value, $message );
+            // `post_url` has no comment property; everything else reads off the
+            // comment via WP_Comment's magic getter (e.g. `post_title` proxies
+            // to the post). Coerce to string so a missing value never reaches
+            // str_replace as null (deprecated since PHP 8.1).
+            $replacement = ( 'post_url' === $search )
+                ? (string) get_permalink( $comment->comment_post_ID )
+                : (string) ( $comment->$value ?? '' );
+
+            $message = str_replace( '{' . $search . '}', $replacement, $message );
         }
 
         $message = $this->replace_global_keys( $message );


### PR DESCRIPTION
Closes getdokan/texty-pro#31

## Problem
`WP\Comment::get_message()` dereferenced `get_comment()` with no null check. The comment notification is dispatched synchronously on `comment_post`, but the comment can be deleted / trashed / flagged as spam before the send fires (e.g. by an anti-spam plugin hooked on `comment_post`). `get_comment()` then returns `null`.

> **Note on severity:** validated against the live code on PHP 8.4 — reading a property on `null` is a **`Warning`, not a fatal**, so there is **no 500** (only a *method call* on null is fatal, and this code only reads properties). The real harm is that the notification still rendered an **empty-bodied message and sent/billed it**: `A new comment added on the post "" by ().`

A second, smaller defect: the `{ip}` token maps to `comment_author_ip` (lowercase), but the `WP_Comment` property is `comment_author_IP`. The case mismatch makes it resolve to `null`, which triggered a `str_replace(): Passing null` deprecation on **every** comment, even the happy path.

## Fix
- **`Dispatcher::new_comment()`** bails when `get_comment()` doesn't return a `WP_Comment`, so a missing comment never renders or bills an SMS.
- **`Comment::get_message()`** null-guards the comment and coerces every token value to string (`(string) ( $comment->$value ?? '' )`), so a missing value never reaches `str_replace()` as `null`. This also clears the `{ip}` deprecation.

`{post_title}` is intentionally left unchanged — it already resolves correctly through `WP_Comment`'s magic `__get`, which proxies post fields to the post (verified: renders the real title). The issue's claim that `{post_title}` renders empty is incorrect.

## Out of scope (flagged for product decision)
The `{ip}` token currently renders **empty** because of the case typo, so the commenter's IP is **not** exposed today. "Fixing the case" to `comment_author_IP` would *start* leaking it into the SMS and logs. Dropping the token is a deliberate product call, not made here.

## Acceptance criteria
- [x] Sending after the comment is deleted returns gracefully (no warning flood, no billed empty SMS).
- [x] `{post_title}` and `{post_url}` resolve to the real post title / permalink.
- [x] No PHP 8.1 `str_replace(null)` deprecation.

## Verification
Validated on PHP 8.4.11 / WP-CLI:
- `Dispatcher::new_comment( <deleted id> )` → bails cleanly, no send, no warning.
- `get_message()` on a deleted comment → no warnings/deprecations.
- `get_message()` on a normal comment → renders title + author + URL, **no** `str_replace(null)` deprecation.
- `php -l` clean; `composer phpcs` clean (0 errors) on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)