### PR TITLE
refactor(deps): scope wedevs/wp-kit via Mozart

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "appsero/client": "^v2.0.4",
-        "wedevs/wp-kit": "dev-main"
-
+        "php": ">=7.4"
     },
     "repositories": [
         {
@@ -29,6 +27,8 @@
         }
     },
     "require-dev": {
+        "appsero/client": "^v2.0.4",
+        "wedevs/wp-kit": "dev-main",
         "tareq1988/wp-php-cs-fixer": "dev-master",
         "wp-coding-standards/wpcs": "dev-develop",
         "phpcompatibility/php-compatibility": "*",
@@ -65,7 +65,8 @@
             "classmap_prefix": "Texty_",
             "packages": [
                 "appsero/updater",
-                "appsero/client"
+                "appsero/client",
+                "wedevs/wp-kit"
             ],
             "excluded_packages": [
                 "psr/container"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b54b6611ad4be6e7ea80e827e628cdf",
-    "packages": [
+    "content-hash": "20546b32c06fad9667fb4d007bdc5645",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "appsero/client",
             "version": "v2.0.6",
@@ -60,70 +61,6 @@
             },
             "time": "2026-02-24T04:46:05+00:00"
         },
-        {
-            "name": "wedevs/wp-kit",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/getdokan/wp-kit.git",
-                "reference": "e8de3cc6dd090965469f072dc1065247e73181b5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/getdokan/wp-kit/zipball/e8de3cc6dd090965469f072dc1065247e73181b5",
-                "reference": "e8de3cc6dd090965469f072dc1065247e73181b5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "brain/monkey": "^2.6",
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "mockery/mockery": "^1.6",
-                "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "phpunit/phpunit": "^9.0 || ^10.0",
-                "squizlabs/php_codesniffer": "^3.7",
-                "wp-coding-standards/wpcs": "^3.0"
-            },
-            "default-branch": true,
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "WeDevs\\WPKit\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "WeDevs\\WPKit\\Tests\\": "tests/phpunit/tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ],
-                "phpcs": [
-                    "phpcs"
-                ],
-                "phpcbf": [
-                    "phpcbf"
-                ],
-                "lint": [
-                    "@phpcs"
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "WordPress toolkit: DataLayer, Migration, Admin Notifications",
-            "support": {
-                "source": "https://github.com/getdokan/wp-kit/tree/main",
-                "issues": "https://github.com/getdokan/wp-kit/issues"
-            },
-            "time": "2026-03-05T05:55:18+00:00"
-        }
-    ],
-    "packages-dev": [
         {
             "name": "coenjacobs/mozart",
             "version": "0.7.1",
@@ -1858,6 +1795,68 @@
             "time": "2023-06-19T06:26:04+00:00"
         },
         {
+            "name": "wedevs/wp-kit",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/getdokan/wp-kit.git",
+                "reference": "e8de3cc6dd090965469f072dc1065247e73181b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/getdokan/wp-kit/zipball/e8de3cc6dd090965469f072dc1065247e73181b5",
+                "reference": "e8de3cc6dd090965469f072dc1065247e73181b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "brain/monkey": "^2.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "mockery/mockery": "^1.6",
+                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "phpunit/phpunit": "^9.0 || ^10.0",
+                "squizlabs/php_codesniffer": "^3.7",
+                "wp-coding-standards/wpcs": "^3.0"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WeDevs\\WPKit\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "WeDevs\\WPKit\\Tests\\": "tests/phpunit/tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "phpcs": [
+                    "phpcs"
+                ],
+                "phpcbf": [
+                    "phpcbf"
+                ],
+                "lint": [
+                    "@phpcs"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "WordPress toolkit: DataLayer, Migration, Admin Notifications",
+            "support": {
+                "source": "https://github.com/getdokan/wp-kit/tree/main",
+                "issues": "https://github.com/getdokan/wp-kit/issues"
+            },
+            "time": "2026-03-05T05:55:18+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "dev-develop",
             "source": {
@@ -1934,7 +1933,9 @@
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=7.4"
+    },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/Api/Logs.php
+++ b/includes/Api/Logs.php
@@ -16,7 +16,7 @@
 namespace Texty\Api;
 
 use Texty\Models\SmsStat;
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/includes/Api/Metrics.php
+++ b/includes/Api/Metrics.php
@@ -6,7 +6,7 @@ use DateTimeImmutable;
 use Exception;
 use Texty\Models\SmsStat;
 use Texty\Models\SmsStatStore;
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;

--- a/includes/Api/SettingsController.php
+++ b/includes/Api/SettingsController.php
@@ -26,7 +26,7 @@
 namespace Texty\Api;
 
 use Texty\Gateways\GatewayInterface;
-use WeDevs\WPKit\Settings\BaseSettingsRESTController;
+use Texty\Dependencies\WeDevs\WPKit\Settings\BaseSettingsRESTController;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -318,7 +318,7 @@ class SettingsController extends BaseSettingsRESTController {
 	/**
 	 * The key the frontend uses for a field's value.
 	 *
-	 * plugin-ui's SettingsProvider keys its flat values map by the raw field
+	 * The plugin-ui SettingsProvider keys its flat values map by the raw field
 	 * element `id` (see `collectKeys` in settings-context), so field ids must
 	 * be globally unique — hence the `<gateway>_<field>` naming in the schema.
 	 *

--- a/includes/Dispatcher.php
+++ b/includes/Dispatcher.php
@@ -5,7 +5,7 @@ namespace Texty;
 use Texty\Integrations\Dokan;
 use Texty\Integrations\WooCommerce;
 use Texty\Models\SmsStat;
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 use Texty\Gateways\GatewayInterface;
 
 /**

--- a/includes/Install.php
+++ b/includes/Install.php
@@ -4,7 +4,7 @@ namespace Texty;
 
 use Texty\Models\SmsStat;
 use Texty\Models\SmsStatStore;
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 
 /**
  * Installer Class

--- a/includes/Migrations.php
+++ b/includes/Migrations.php
@@ -19,10 +19,10 @@ namespace Texty;
 use Texty\Migrations\NoticeProvider;
 use Texty\Migrations\TextyMigration;
 use Texty\Migrations\V_2_0_0;
-use WeDevs\WPKit\Migration\MigrationHooks;
-use WeDevs\WPKit\Migration\MigrationManager;
-use WeDevs\WPKit\Migration\MigrationRegistry;
-use WeDevs\WPKit\Migration\MigrationRESTController;
+use Texty\Dependencies\WeDevs\WPKit\Migration\MigrationHooks;
+use Texty\Dependencies\WeDevs\WPKit\Migration\MigrationManager;
+use Texty\Dependencies\WeDevs\WPKit\Migration\MigrationRegistry;
+use Texty\Dependencies\WeDevs\WPKit\Migration\MigrationRESTController;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/Migrations/NoticeProvider.php
+++ b/includes/Migrations/NoticeProvider.php
@@ -10,8 +10,8 @@
 namespace Texty\Migrations;
 
 use Throwable;
-use WeDevs\WPKit\AdminNotification\Contracts\NoticeProviderInterface;
-use WeDevs\WPKit\AdminNotification\Notice;
+use Texty\Dependencies\WeDevs\WPKit\AdminNotification\Contracts\NoticeProviderInterface;
+use Texty\Dependencies\WeDevs\WPKit\AdminNotification\Notice;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/Migrations/TextyMigration.php
+++ b/includes/Migrations/TextyMigration.php
@@ -8,7 +8,7 @@
 
 namespace Texty\Migrations;
 
-use WeDevs\WPKit\Migration\BaseMigration;
+use Texty\Dependencies\WeDevs\WPKit\Migration\BaseMigration;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/includes/Models/SmsStat.php
+++ b/includes/Models/SmsStat.php
@@ -2,8 +2,8 @@
 
 namespace Texty\Models;
 
-use WeDevs\WPKit\DataLayer\Model\BaseModel;
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\Model\BaseModel;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 
 /**
  * SMS Statistics Model

--- a/includes/Models/SmsStatStore.php
+++ b/includes/Models/SmsStatStore.php
@@ -2,7 +2,7 @@
 
 namespace Texty\Models;
 
-use WeDevs\WPKit\DataLayer\DataStore\BaseDataStore;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataStore\BaseDataStore;
 
 /**
  * SMS Statistics DataStore

--- a/includes/Notices.php
+++ b/includes/Notices.php
@@ -13,9 +13,9 @@
 
 namespace Texty;
 
-use WeDevs\WPKit\AdminNotification\Contracts\NoticeProviderInterface;
-use WeDevs\WPKit\AdminNotification\NoticeManager;
-use WeDevs\WPKit\AdminNotification\NoticeRESTController;
+use Texty\Dependencies\WeDevs\WPKit\AdminNotification\Contracts\NoticeProviderInterface;
+use Texty\Dependencies\WeDevs\WPKit\AdminNotification\NoticeManager;
+use Texty\Dependencies\WeDevs\WPKit\AdminNotification\NoticeRESTController;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/texty.php
+++ b/texty.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 
 require __DIR__ . '/vendor/autoload.php';
 
-use WeDevs\WPKit\DataLayer\DataLayerFactory;
+use Texty\Dependencies\WeDevs\WPKit\DataLayer\DataLayerFactory;
 
 /**
  * Texty Class


### PR DESCRIPTION
## What

Vendor **wedevs/wp-kit** under the `Texty\Dependencies\` namespace via Mozart, matching how Appsero is already scoped.

## Why

Previously `wedevs/wp-kit` loaded under its own `WeDevs\WPKit\` namespace from `vendor/`. If another active plugin ships its own (possibly different-version) copy of wp-kit under the same namespace, the two collide — whichever autoloads first wins, and the loser silently runs against the wrong class definitions. Scoping isolates Texty's copy.

## Changes

- Add `wedevs/wp-kit` to `extra.mozart.packages`.
- Rewrite every `use WeDevs\WPKit\...` → `use Texty\Dependencies\WeDevs\WPKit\...` (19 imports across `includes/` + `texty.php`).
- Move `appsero/client` and `wedevs/wp-kit` from `require` → `require-dev`. In a production `composer install --no-dev` mozart doesn't run, so keeping them in `require` pulled **unscoped** copies into `vendor/` alongside the scoped `dependencies/` output. As dev deps, `--no-dev` no longer installs them; runtime resolves both from the generated `dependencies/` dir (same model Appsero already relies on).

## Verification

- `mozart compose` generates `dependencies/WeDevs/WPKit/**` with the rewritten namespace; `vendor/wedevs` + `vendor/appsero` deleted.
- Autoloader exposes only `Texty\Dependencies\` → `dependencies/`; no live unscoped `WeDevs\WPKit\` / `Appsero\` mappings.
- Scoped classes resolve; old `WeDevs\WPKit\...` no longer resolves.
- `composer install --no-dev` dry-run: neither package lands in `vendor/`.

## No data/state impact

Scoping renamed only wp-kit internals. Everything Texty persists as identity stays in the untouched `Texty\` namespace:
- Migrations are keyed by version string (`texty_db_version`), and registered migration classes (`V_2_0_0::class`, etc.) are `Texty\...` — unaffected.
- DataLayer store registry is runtime-only; `Texty\Models\SmsStat` unscoped; table uses the `texty` prefix, not a FQCN.
- wp-kit `BackgroundProcess` (keys off `md5(static::class)`) is not used by Texty.
- No option/meta stores a `WeDevs\WPKit` FQCN.

## Note for reviewers

`dependencies/` is gitignored (generated by mozart on a dev `composer install`). `bin/build.sh` copies it into the zip, then runs `--no-dev`. A dev `composer install` must run before building so the scoped output exists — already the assumption for Appsero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin’s minimum PHP requirement to 7.4.
  * Adjusted bundled dependencies so the plugin uses its included copies consistently.

* **Bug Fixes**
  * Improved compatibility with newer packaged components, helping prevent runtime issues and installation problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->