### PR TITLE
chore(deps): override uuid to clear the runtime Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8381,6 +8381,19 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
@@ -8435,19 +8448,6 @@
       "integrity": "sha512-Hu0YfNU+38EsTmnUfLXUKFMXq9yz7htGYpF4x+dlbBhUCvIvzLt0yVLT/gJRmvLKFJdqNFrz4eKkIUjIXSr7Tw==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/@wordpress/date": {
@@ -22758,17 +22758,6 @@
         "websocket-driver": "^0.7.4"
       }
     },
-    "node_modules/sockjs/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/socks": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
@@ -24963,16 +24952,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@babel/runtime": "^7.26.10",
-    "serialize-javascript": "^7.0.7"
+    "serialize-javascript": "^7.0.7",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Follow-up to #100. After that merged, 7 Dependabot alerts remained. This clears the only one that **ships to users**.

## uuid (runtime — fixed here)
`@wordpress/components` pulled `uuid@9.0.1` and `sockjs` pulled `8.3.2`, both below the patched `11.1.1`. Added `"uuid": "^11.1.1"` to `overrides`.

- **`npm audit --omit=dev` → 0 vulnerabilities** (nothing vulnerable in `dist/`).
- Verified: `npm run typecheck` ✅ and `npm run build` ✅ with the ESM-only uuid 11.

## The other 6 alerts (dev-only — recommend dismiss, not override)
`minimatch`, `markdown-it`, `webpack-dev-server` (×4) are build tooling **hard-pinned by `@wordpress/scripts@32.5.1` itself** (`webpack-dev-server ^4.15.1`; `markdown-it@12.3.2` exact-pinned by `markdownlint@0.25.1`). They never ship in the plugin. Force-overriding them fights @wordpress/scripts' tested set and risks breaking `npm start` / readme-lint. Best handled by dismissing the alerts as "only in dev dependencies / vulnerable code not used in production," or waiting for an upstream @wordpress/scripts bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency override to a newer version, helping keep the app’s package set current and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->